### PR TITLE
Add description field to pchests to make them renamable

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,0 +1,1 @@
+tubelib?

--- a/init.lua
+++ b/init.lua
@@ -48,18 +48,9 @@ hook.slingshot_onuse=function(itemstack, user)
 end
 
 minetest.register_tool("hook:slingshot", {
-	description = "Slingshot",
+	description = "Slingshot (currently disabled)",
 	range = 4,
 	inventory_image = "hook_slingshot.png",
-	on_use=function(itemstack, user, pointed_thing)
-		local ref = pointed_thing.ref
-		if ref and not (ref:get_luaentity() and ref:get_luaentity().name == "__builtin:item") then
-			hook.punch(user,ref,4)
-			return itemstack
-		end
-		hook.slingshot_onuse(itemstack, user)
-		return itemstack
-	end,
 	on_place=function(itemstack, user, pointed_thing)
 		local item=itemstack:to_table()
 		local meta=minetest.deserialize(item["metadata"])

--- a/pchest.lua
+++ b/pchest.lua
@@ -133,7 +133,11 @@ minetest.register_node("hook:pchest_node", {
 		return m:get_string("owner") == "" and m:get_inventory():is_empty("main")
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
+		local name = sender:get_player_name()
 		local meta = minetest.get_meta(pos)
+		if name ~= meta:get_string("owner") then
+			return false
+		end
 		if fields.description_textbox then
 			meta:set_string("description", fields.description_textbox)
 		end


### PR DESCRIPTION
Fixes #4 

Made portable chests renamable by adding a "description" field to the formspec, which is saved as "description" in the item's metadata. This overrides the default description to effectively rename the item once you have picked it up.

This also involved separating out the formspec function from the setup so we can call it again to update the form once it is submitted.

Description defaults to "Portable locked chest"

This new description could also be used to update the infotext, I decided against that since you can just look inside the chest if it's placed down, if you'd like me to make that change in this PR too, let me know.